### PR TITLE
PR for ticket 1777172 | Add standard deviation minimum and maximum response time to statistics.

### DIFF
--- a/src/main/java/com/microfocus/sv/svconfigurator/cli/impl/ViewCLICommandProcessor.java
+++ b/src/main/java/com/microfocus/sv/svconfigurator/cli/impl/ViewCLICommandProcessor.java
@@ -95,13 +95,10 @@ public class ViewCLICommandProcessor extends AbstractProjectCommandProcessor {
             List<Server> servers = CliUtils.obtainServers(line, null, true);
             final String outputFormat = CliUtils.obtainOutputFormat(line);
             final ViewProcessorInput input = new ViewProcessorInput(line.hasOption(PROPERTY_REPORT), proj, lineArgs[0], outputFormat);
-            ServersCommandExecutor executor = new ServersCommandExecutor(
-                    servers, proc.getCommandExecutorFactory());
+            ServersCommandExecutor executor = new ServersCommandExecutor(servers, proc.getCommandExecutorFactory());
             executor.execute(new IServerCommandRunner() {
-
                 @Override
-                public void runCommand(ICommandExecutor executor)
-                        throws AbstractSVCException {
+                public void runCommand(ICommandExecutor executor) throws AbstractSVCException {
                     proc.process(input, executor);
                 }
             });

--- a/src/main/java/com/microfocus/sv/svconfigurator/core/impl/jaxb/ServiceRuntimeReport.java
+++ b/src/main/java/com/microfocus/sv/svconfigurator/core/impl/jaxb/ServiceRuntimeReport.java
@@ -49,6 +49,10 @@ public class ServiceRuntimeReport {
 
     private String serviceId;
 
+    private long lastResponseTime;
+    private long minResponseTime;
+    private long maxResponseTime;
+    private double standardDeviation;
 
     private int uniqueMsgCount;
     private SimulationStatistics simulationStats;
@@ -70,6 +74,43 @@ public class ServiceRuntimeReport {
     //============================== PRIVATE METHODS ==========================================
 
     //============================== GETTERS / SETTERS ========================================
+
+
+    @XmlAttribute(name = "lastResponseTime")
+    public long getLastResponseTime() {
+        return lastResponseTime;
+    }
+
+    public void setLastResponseTime(long lastResponseTime) {
+        this.lastResponseTime = lastResponseTime;
+    }
+
+    @XmlAttribute(name = "standardDeviation")
+    public double getStandardDeviation() {
+        return standardDeviation;
+    }
+
+    public void setStandardDeviation(double standardDeviation) {
+        this.standardDeviation = standardDeviation;
+    }
+
+    @XmlAttribute(name = "minResponseTime")
+    public long getMinResponseTime() {
+        return minResponseTime;
+    }
+
+    public void setMinResponseTime(long minResponseTime) {
+        this.minResponseTime = minResponseTime;
+    }
+
+    @XmlAttribute(name = "maxResponseTime")
+    public long getMaxResponseTime() {
+        return maxResponseTime;
+    }
+
+    public void setMaxResponseTime(long maxResponseTime) {
+        this.maxResponseTime = maxResponseTime;
+    }
 
     @XmlAttribute(name = "messageCount")
     public int getMessageCount() {

--- a/src/main/java/com/microfocus/sv/svconfigurator/processor/printer/TextPrinter.java
+++ b/src/main/java/com/microfocus/sv/svconfigurator/processor/printer/TextPrinter.java
@@ -115,6 +115,12 @@ public class TextPrinter implements IPrinter {
         sb.append(String.format(TABLE_FORMAT_REPORT, "Unique Messages", rep.getUniqueMsgCount()));
         sb.append("\n");
 
+        sb.append(String.format(TABLE_FORMAT_REPORT, "Last Response", rep.getLastResponseTime() + " ms"));
+        sb.append(String.format(TABLE_FORMAT_REPORT, "Max Response", rep.getMaxResponseTime() + " ms"));
+        sb.append(String.format(TABLE_FORMAT_REPORT, "Min Response", rep.getMinResponseTime() + " ms"));
+        sb.append(String.format(TABLE_FORMAT_REPORT, "Standard Deviation", rep.getStandardDeviation() + " ms"));
+        sb.append("\n");
+
         List<String> clients = rep.getClientIds();
         if (clients != null) {
             sb.append(String.format(TABLE_FORMAT_REPORT, "Clients Count", clients.size()));


### PR DESCRIPTION
The ticket asked for that the statistics can be accessed from SVConfigurator as well.